### PR TITLE
✏️ Fixes link to anchor in NVIDIA Optimus docs

### DIFF
--- a/src/config/graphics/optimus.md
+++ b/src/config/graphics/optimus.md
@@ -25,7 +25,7 @@ which means you have to uninstall `nvidia` and install the legacy `nvidia390`.
 
 A summary of the methods supported by Void:
 
-[PRIME Render Offload](#PRIME Render Offload)
+[PRIME Render Offload](#prime-render-offload)
 
 - only available on `nvidia`
 - allows to switch to the NVIDIA GPU on a per-application basis


### PR DESCRIPTION
The documentation for NVIDIA Optimus has a broken link which should point to an anchor on the page; these changes correct a typo which appears to be the cause of the issue.